### PR TITLE
Fix duplicate response_format in Gemini requests

### DIFF
--- a/services/llm.py
+++ b/services/llm.py
@@ -220,10 +220,10 @@ class LLMService:
                     "temperature": temperature,
                     "top_p": top_p,
                     "max_tokens": max_tokens,
+                    "response_format": {"type": "text"},
                 }
 
                 if provider == 'gemini':
-                    request_kwargs["response_format"] = {"type": "text"}
                     completion = await client.chat.completions.create(**request_kwargs)
                     try:
                         full_content = LLMService._extract_valid_content(completion, provider_display_name)
@@ -232,7 +232,8 @@ class LLMService:
                     if stream_callback:
                         stream_callback(full_content)
                 else:
-                    stream = await client.chat.completions.create(stream=True, response_format={"type": "text"}, **request_kwargs)
+                    request_kwargs["stream"] = True
+                    stream = await client.chat.completions.create(**request_kwargs)
                     full_content = ""
                     async for chunk in stream:
                         if chunk.choices[0].delta.content:
@@ -359,10 +360,10 @@ class LLMService:
                     "temperature": temperature,
                     "top_p": top_p,
                     "max_tokens": max_tokens,
+                    "response_format": {"type": "text"},
                 }
 
                 if provider == 'gemini':
-                    request_kwargs["response_format"] = {"type": "text"}
                     completion = await client.chat.completions.create(**request_kwargs)
                     try:
                         full_content = LLMService._extract_valid_content(completion, provider_display_name)
@@ -371,7 +372,8 @@ class LLMService:
                     if stream_callback:
                         stream_callback(full_content)
                 else:
-                    stream = await client.chat.completions.create(stream=True, response_format={"type": "text"}, **request_kwargs)
+                    request_kwargs["stream"] = True
+                    stream = await client.chat.completions.create(**request_kwargs)
                     full_content = ""
                     async for chunk in stream:
                         if chunk.choices[0].delta.content:

--- a/services/vlm.py
+++ b/services/vlm.py
@@ -296,10 +296,10 @@ class VisionService:
                     "max_tokens": max_tokens,
                     "temperature": temperature,
                     "top_p": top_p,
+                    "response_format": {"type": "text"},
                 }
 
                 if provider == 'gemini':
-                    request_kwargs["response_format"] = {"type": "text"}
                     resp = await client.chat.completions.create(**request_kwargs)
                     try:
                         full_content = VisionService._extract_valid_content(resp, provider_display_name)
@@ -308,7 +308,8 @@ class VisionService:
                     if stream_callback:
                         stream_callback(full_content)
                 else:
-                    resp = await client.chat.completions.create(stream=True, response_format={"type": "text"}, **request_kwargs)
+                    request_kwargs["stream"] = True
+                    resp = await client.chat.completions.create(**request_kwargs)
                     full_content = ""
                     async for chunk in resp:
                         if chunk.choices[0].delta.content:


### PR DESCRIPTION
## Summary
- prevent duplicate `response_format` args when calling Gemini vision and language models
- set streaming via request kwargs for non-Gemini providers

## Testing
- `python -m py_compile config_manager.py services/llm.py services/vlm.py services/cloud.py services/baidu.py server.py node/translate_node.py`
- `node --check js/services/api.js js/services/interceptor.js js/modules/PromptAssistant.js js/modules/settings.js js/modules/apiConfigManager.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac2a901368832baa64268f9bf73426